### PR TITLE
Replace Django urls.url() to re_path

### DIFF
--- a/swagger_example/urls.py
+++ b/swagger_example/urls.py
@@ -13,9 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf.urls import url
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
@@ -32,7 +31,7 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    url('^showroom/', include('showroom_manager.urls')),
+    re_path('^showroom/', include('showroom_manager.urls')),
     path('admin/', admin.site.urls),
-    url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]


### PR DESCRIPTION
django.conf.urls.url() was deprecated in Django 3.0, and is removed in Django 4.0+.

I fix it by replace url() with [re_path()](https://docs.djangoproject.com/en/stable/ref/urls/#re_path)

fixes #1 